### PR TITLE
Add order viewing window

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ A Tkinter-based GUI application for tracking YBS orders. The script logs into th
    python OrderTracker.py
    ```
 
-The program will prompt for YBS credentials. Once logged in, it will periodically scrape order data and store updates in a local SQLite database (`orders.db`). Use the "Scrape & Export Order" button to export an order's history as a CSV file.
+The program will prompt for YBS credentials. Once logged in, it will periodically scrape order data and store updates in a local SQLite database (`orders.db`). Use the "Scrape & Export Order" button to export an order's history as a CSV file. The interface also includes a **View Orders** button which opens a window showing all order numbers stored in the local database. Selecting an order displays its recorded workstation history.
 The login screen also includes a **Base URL** field for the YBS site. If left blank, it defaults to `https://www.ybsnow.com`.


### PR DESCRIPTION
## Summary
- add `View Orders` button to GUI
- implement a new window for browsing stored order numbers
- document how to use the new feature

## Testing
- `python3 -m py_compile OrderTracker.py`


------
https://chatgpt.com/codex/tasks/task_e_688931279580832d995e5b04a037173e