### PR TITLE
Notify user when login fails in update loop

### DIFF
--- a/OrderTracker.py
+++ b/OrderTracker.py
@@ -289,6 +289,8 @@ class YBSScraperApp:
             except Exception:
                 pass
             self.refresh_log_display()
+        else:
+            messagebox.showerror("Login Failed", "Could not log in to YBS.")
         self.root.after(60000, self.update_loop)
 
     def start_update_loop(self):


### PR DESCRIPTION
## Summary
- show an error dialog if automatic login fails in `update_loop`

## Testing
- `python -m py_compile OrderTracker.py`

------
https://chatgpt.com/codex/tasks/task_e_68893b1d7db0832d9f94f0458164b7fd