### PR TITLE
Add status indicator with last HTML parse time

### DIFF
--- a/OrderTracker.py
+++ b/OrderTracker.py
@@ -93,6 +93,11 @@ class YBSScraperApp:
         self.log_text = scrolledtext.ScrolledText(self.root, height=10)
         self.log_text.pack(fill="both", expand=True, padx=10, pady=10)
 
+        # status indicator
+        self.status_var = tk.StringVar(value="Idle")
+        self.status_label = tk.Label(self.root, textvariable=self.status_var, anchor="w")
+        self.status_label.pack(fill="x", padx=10, pady=(0, 10))
+
         self.start_update_loop()
 
     def save_creds(self):
@@ -315,6 +320,7 @@ class YBSScraperApp:
             self.log_text.insert(tk.END, f"{order_num} - {ws} - {ts}\n")
 
     def update_loop(self):
+        self.status_var.set("Updating...")
         session = requests.Session()
         if self.do_login(session):
             self.update_orders(session)
@@ -325,8 +331,12 @@ class YBSScraperApp:
             except Exception:
                 pass
             self.refresh_log_display()
+            self.status_var.set(
+                f"Last updated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+            )
         else:
             messagebox.showerror("Login Failed", "Could not log in to YBS.")
+            self.status_var.set("Update failed")
         self.root.after(60000, self.update_loop)
 
     def start_update_loop(self):

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ A Tkinter-based GUI application for tracking YBS orders. The script logs into th
    python OrderTracker.py
    ```
 
-The program will prompt for YBS credentials. Once logged in, it will periodically scrape order data and store updates in a local SQLite database (`orders.db`). Use the "Scrape & Export Order" button to export an order's history as a CSV file. The interface also includes a **View Orders** button which opens a window showing all order numbers stored in the local database. Selecting an order displays its recorded workstation history.
+The program will prompt for YBS credentials. Once logged in, it will periodically scrape order data and store updates in a local SQLite database (`orders.db`). Use the "Scrape & Export Order" button to export an order's history as a CSV file. The interface also includes a **View Orders** button which opens a window showing all order numbers stored in the local database. Selecting an order displays its recorded workstation history. A status bar at the bottom of the main window indicates when data was last fetched and parsed so you can confirm the application is actively recording information.
 The login screen also includes a **Base URL** field for the YBS site. If left blank, it defaults to `https://www.ybsnow.com`.


### PR DESCRIPTION
## Summary
- add a status bar to indicate the app is actively recording data
- update the status bar during each refresh with the time HTML was parsed
- document the new status indicator in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889571ea9b4832d8165fe824d9ee74c