### PR TITLE
Update to load orders at startup

### DIFF
--- a/OrderTracker.py
+++ b/OrderTracker.py
@@ -51,6 +51,13 @@ class YBSScraperApp:
         self.conn.commit()
 
         self.create_gui()
+
+        # Load current orders immediately if credentials are available.
+        if self.settings.get("username") and self.settings.get("password"):
+            try:
+                self.update_once()
+            except Exception as e:
+                logging.exception("Initial load failed: %s", e)
     
     def create_gui(self):
         self.frame = tk.Frame(self.root)


### PR DESCRIPTION
## Summary
- call `update_once` after GUI creation to load current orders immediately

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68896d6de6a4832d95f485b7ae27d25c