### PR TITLE
Fix SQLite connection error in background thread

### DIFF
--- a/OrderTracker.py
+++ b/OrderTracker.py
@@ -37,7 +37,8 @@ class YBSScraperApp:
         self.settings = load_settings()
 
         # database setup
-        self.conn = sqlite3.connect(DB_FILE)
+        # allow using the connection from the background update thread
+        self.conn = sqlite3.connect(DB_FILE, check_same_thread=False)
         c = self.conn.cursor()
         c.execute(
             """


### PR DESCRIPTION
## Summary
- use `check_same_thread=False` when opening the SQLite connection so the update thread can reuse it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a68476fbc832d82ba49695cb667d4