### PR TITLE
Fix login persistence and manage page scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ The login screen also includes a **Base URL** field for the YBS site. If left bl
 When the application launches it also opens a small browser frame attached to
 the right of the main interface. This frame displays `manage.html` from the YBS
 site using the `tkinterweb` widget so you can monitor the page directly within
-the application. The page is scaled down and includes scrollbars for easier
-navigation.
+the application. The browser is loaded using the application's authenticated
+session so it remains logged in. The scraper always pulls data from
+`manage.html`, never from the login page.


### PR DESCRIPTION
## Summary
- embed `manage.html` in the GUI using the authenticated session
- add `reload_manage_page` helper for loading the manage page
- re-check authentication when scraping and re-login if needed
- load the browser frame after each update and export
- document that scraping only reads `manage.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aaa82dd0c832d838b388f720d9465